### PR TITLE
fix: a typo error

### DIFF
--- a/src-tauri/src/i18n/mod.rs
+++ b/src-tauri/src/i18n/mod.rs
@@ -21,7 +21,7 @@ pub enum Locale {
 impl From<String> for Locale {
     fn from(value: String) -> Self {
         match value.as_ref() {
-            "zh-CNa" => Self::ZhCN,
+            "zh-CN" => Self::ZhCN,
             _ => Self::EnUS,
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the locale recognition for "zh-CNa" to accurately match "zh-CN". This ensures proper functionality when converting locale strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->