### PR TITLE
feat(i18n): add macOS-specific locale handling

### DIFF
--- a/src-tauri/src/i18n/mod.rs
+++ b/src-tauri/src/i18n/mod.rs
@@ -19,9 +19,18 @@ pub enum Locale {
 }
 
 impl From<String> for Locale {
+    #[cfg(target_os = "windows")]
     fn from(value: String) -> Self {
         match value.as_ref() {
             "zh-CN" => Self::ZhCN,
+            _ => Self::EnUS,
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn from(value: String) -> Self {
+        match value.as_ref() {
+            "zh-Hans-CN" => Self::ZhCN,
             _ => Self::EnUS,
         }
     }


### PR DESCRIPTION
- Added a macOS-specific implementation for the `Locale::from` function to handle the "zh-Hans-CN" locale.
- Retained the existing Windows-specific implementation for "zh-CN".