### PR TITLE
fix(i18n): resolve locale issue on Linux systems

### DIFF
--- a/src-tauri/src/i18n/mod.rs
+++ b/src-tauri/src/i18n/mod.rs
@@ -19,7 +19,7 @@ pub enum Locale {
 }
 
 impl From<String> for Locale {
-    #[cfg(target_os = "windows")]
+    #[cfg(not(target_os = "macos"))]
     fn from(value: String) -> Self {
         match value.as_ref() {
             "zh-CN" => Self::ZhCN,


### PR DESCRIPTION
The previous condition `#[cfg(target_os = "windows")]` incorrectly limited the locale conversion logic to Windows only. This commit updates the condition to `#[cfg(not(target_os = "macos"))]` to ensure proper locale handling on Linux systems.